### PR TITLE
Fix login endpoint

### DIFF
--- a/Gotcha/SessionEndpoint.swift
+++ b/Gotcha/SessionEndpoint.swift
@@ -16,7 +16,8 @@ class SessionEndpoint {
     func login(email_address: String, password: String, onCompletion: @escaping (JSON) -> Void)
     {
         var body: [String: Any] {
-            return ["data": ["attributes": ["email_address": email_address, "password": password]]]
+            return ["data": ["type": "session",
+                             "attributes": ["email_address": email_address, "password": password]]]
         }
         
         RestAPIManager.sharedInstance.makeHTTPPostRequest(path: route, body: body, authRequired: false, onCompletion: { json, err in


### PR DESCRIPTION
This PR adds the `type` node to the body of the sessions endpoint `POST /api/sessions` that is called when a user logs in.

This is needed because types are now checked in the API.