### PR TITLE
Fix register device endpoint

### DIFF
--- a/Gotcha/DevicesEndpoint.swift
+++ b/Gotcha/DevicesEndpoint.swift
@@ -16,7 +16,7 @@ class DevicesEndpoint {
     func registerDevice(deviceToken: String, onCompletion: @escaping (JSON) -> Void)
     {
         var body: [String: Any] {
-            return ["data": ["attributes": ["token": deviceToken]]]
+            return ["data": ["type": "device", "attributes": ["token": deviceToken]]]
         }
         
         RestAPIManager.sharedInstance.makeHTTPPostRequest(path: route, body: body, authRequired: true, onCompletion: { json, err in


### PR DESCRIPTION
This PR adds the type node to the body of the register device endpoint POST /api/devices that is called after a user logs in or registers.

This is needed because types are now checked in the API.