### PR TITLE
Load scores for players

### DIFF
--- a/Gotcha.xcodeproj/project.pbxproj
+++ b/Gotcha.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2117C2DD20A3E4670060B85B /* ScoresEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2117C2DC20A3E4670060B85B /* ScoresEndpoint.swift */; };
 		7CE939975595D2EF2F21AD09 /* Pods_GotchaTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E92D5A7043FBCD91DF11FD31 /* Pods_GotchaTests.framework */; };
 		952124F62079DC6C00B8452F /* PlayersEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 952124F52079DC6C00B8452F /* PlayersEndpoint.swift */; };
 		952124F82079DD3A00B8452F /* SessionEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 952124F72079DD3A00B8452F /* SessionEndpoint.swift */; };
@@ -66,6 +67,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2117C2DC20A3E4670060B85B /* ScoresEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScoresEndpoint.swift; sourceTree = "<group>"; };
 		3D38CD69D36DBBEFF2BD74D6 /* Pods-Gotcha.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Gotcha.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Gotcha/Pods-Gotcha.debug.xcconfig"; sourceTree = "<group>"; };
 		56BC6F43DDB31ED6276CE170 /* Pods-GotchaTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GotchaTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-GotchaTests/Pods-GotchaTests.release.xcconfig"; sourceTree = "<group>"; };
 		952124F52079DC6C00B8452F /* PlayersEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayersEndpoint.swift; sourceTree = "<group>"; };
@@ -155,6 +157,7 @@
 				952124FB2079DD5C00B8452F /* DevicesEndpoint.swift */,
 				952124FD2079DD7400B8452F /* MatchesEndpoint.swift */,
 				953D8439202E70CA001E4FD7 /* RestAPIManager.swift */,
+				2117C2DC20A3E4670060B85B /* ScoresEndpoint.swift */,
 			);
 			name = API;
 			sourceTree = "<group>";
@@ -533,6 +536,7 @@
 				95ABFF552051C41E00C3F032 /* UITextField.swift in Sources */,
 				95ABFF682051C59300C3F032 /* Date.swift in Sources */,
 				954A396B20685A0D00222775 /* Data.swift in Sources */,
+				2117C2DD20A3E4670060B85B /* ScoresEndpoint.swift in Sources */,
 				95E52AD320361E9300A66B92 /* GlobalState.swift in Sources */,
 				95ABFF622051C52500C3F032 /* String.swift in Sources */,
 				952124F62079DC6C00B8452F /* PlayersEndpoint.swift in Sources */,

--- a/Gotcha/ArenasEndpoint.swift
+++ b/Gotcha/ArenasEndpoint.swift
@@ -39,13 +39,4 @@ class ArenasEndpoint {
             onCompletion(json as JSON)
         })
     }
-    
-    func getScores(arena: Int, onCompletion: @escaping (JSON) -> Void)
-    {
-        let path = route + "/\(arena)/scores"
-        
-        RestAPIManager.sharedInstance.makeHTTPGetRequest(path: path, onCompletion: { json, err in
-            onCompletion(json as JSON)
-        })
-    }
 }

--- a/Gotcha/MatchViewController.swift
+++ b/Gotcha/MatchViewController.swift
@@ -45,8 +45,17 @@ class MatchViewController: UIViewController {
                     let opponent = Player(json: json["data"])
                     self.imgOpponentAvatar.downloadedFrom(link: opponent.avatar!)
                     self.lblOpponentName.text = opponent.name!
-                    self.lblOpponentRank.text = "#2"
-                    self.lblOpponentPoints.text = "55"
+                }
+            })
+            
+            //GET Scores for Opponent
+            ScoresEndpoint.sharedInstance.getScores(playerId: (GlobalState.Match?.opponent)!,
+                                                    arenaId: (GlobalState.Match?.arena)!,
+                                                    onCompletion: { (json: JSON) in
+                let score = Score(json: json["meta"])
+                DispatchQueue.main.async {
+                    self.lblOpponentPoints.text = String(describing: score.totalPoints!)
+                    self.lblOpponentRank.text = score.placement
                 }
             })
             
@@ -57,21 +66,19 @@ class MatchViewController: UIViewController {
                     let opponent = Player(json: json["data"])
                     self.imgSeekerAvatar.downloadedFrom(link: opponent.avatar!)
                     self.lblSeekerName.text = opponent.name!
-                    self.lblSeekerRank.text = "#2"
-                    self.lblSeekerPoints.text = "55"
                 }
             })
             
-            //GET Scores
-            ArenasEndpoint.sharedInstance.getScores(arena: (GlobalState.Match?.arena)!, onCompletion: { (json: JSON) in
-                
-//                let score = Score(json: json["meta"])
-//                DispatchQueue.main.async {
-//
-//                }
-                
+            //GET Scores for Seeker
+            ScoresEndpoint.sharedInstance.getScores(playerId: (GlobalState.Match?.seeker)!,
+                                                    arenaId: (GlobalState.Match?.arena)!,
+                                                    onCompletion: { (json: JSON) in
+                let score = Score(json: json["meta"])
+                DispatchQueue.main.async {
+                    self.lblSeekerPoints.text = String(describing: score.totalPoints!)
+                    self.lblSeekerRank.text = score.placement
+                }
             })
-
         }
     }
 

--- a/Gotcha/PlayerWaitingViewController.swift
+++ b/Gotcha/PlayerWaitingViewController.swift
@@ -43,8 +43,9 @@ class PlayerWaitingViewController: UIViewController {
         lblPlayerName.text = GlobalState.Player?.name!
         imgPlayerAvatar.downloadedFrom(link: (GlobalState.Player?.avatar!)!)
         
-        ArenasEndpoint.sharedInstance.getScores(arena: (arena?.id)!, onCompletion: { (json: JSON) in
-            
+        ScoresEndpoint.sharedInstance.getScores(playerId: (GlobalState.Player?.id)!,
+                                                arenaId: (arena?.id)!,
+                                                onCompletion: { (json: JSON) in
             let score = Score(json: json["meta"])
             DispatchQueue.main.async {
                 self.lblPlayerPoints.text = String(describing: score.totalPoints!)

--- a/Gotcha/ScoresEndpoint.swift
+++ b/Gotcha/ScoresEndpoint.swift
@@ -1,0 +1,25 @@
+//
+//  ScoresEndpoint.swift
+//  Gotcha
+//
+//  Created by Don Miller on 5/9/18.
+//  Copyright © 2018 GroundSpeed. All rights reserved.
+//
+
+import SwiftyJSON
+
+class ScoresEndpoint {
+    
+    static let sharedInstance = ScoresEndpoint()
+    let route = Constants.BaseUrl + "/scores"
+    
+    func getScores(playerId: Int, arenaId: Int, onCompletion: @escaping (JSON) -> Void)
+    {
+        let path = route + "?filter[player]=\(playerId)&filter[arena]=\(arenaId)"
+        
+        RestAPIManager.sharedInstance.makeHTTPGetRequest(path: path, onCompletion: { json, err in
+            onCompletion(json as JSON)
+        })
+    }
+    
+}


### PR DESCRIPTION
This PR adds the new `GET /api/scores` endpoint and the filter to allow the client to retrieve scores for any `Player` and `Arena`.

This was needed as the old `GET /api/arenas/:id/scores` only returned scores for the current player and that did not work for the opponent or seeker.

All the areas where the scores are listed (waiting view and match view) use the data from the API.

NOTE: The match view was not tested as I did not know how to get to that view controller.

*NOTE*: The PR #15 should be merged first as this PR contains that same commit.